### PR TITLE
Adding buildProfile functionality for constructing optimizer options dynamically

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,6 +43,14 @@ module.exports = function(grunt) {
           name: 'project',
           out: 'tmp/requirejs-template.js'
         }
+      },
+      profile: {
+        options: {
+          name: 'project',
+          buildProfile: {
+            path: 'test/fixtures/buildProfile.js'
+          }
+        }
       }
     },
 

--- a/tasks/requirejs.js
+++ b/tasks/requirejs.js
@@ -9,6 +9,7 @@
 module.exports = function(grunt) {
   'use strict';
 
+  var resolve = require('path').resolve;
   var requirejs = require('requirejs');
 
   // TODO: extend this to send build log to grunt.log.ok / grunt.log.error
@@ -32,8 +33,40 @@ module.exports = function(grunt) {
     });
     grunt.verbose.writeflags(options, 'Options');
 
+    if (options.buildProfile && options.buildProfile.path) {
+      options = build(options, options.buildProfile);
+
+      // clean up the passed options, just to be safe
+      delete options.buildProfile;
+
+      grunt.verbose.writeflags(options, 'buildProfile Merged Options');
+    }
+
     requirejs.optimize(options, function(response) {
       done();
     });
   });
+
+  function build (options, buildProfile) {
+    var profilePath = resolve(buildProfile.path);
+    var profileOptions = buildProfile.options || {};
+    var profile = require(profilePath)(profileOptions);
+
+    var a = profile;
+    var b = options;
+    if (buildProfile.override === true) {
+      // if the override flag is set, buildProfile will override passed options
+      a = options;
+      b = profile;
+    }
+
+    return extend(a, b);
+  };
+
+  function extend(a, b) {
+    Object.keys(b).forEach(function(key) {
+      a[key] = b[key];
+    });
+    return a;
+  };
 };

--- a/test/fixtures/buildProfile.js
+++ b/test/fixtures/buildProfile.js
@@ -1,0 +1,19 @@
+
+// Dynamically construct a test build profile
+
+var fs = require('fs');
+
+module.exports = function (options) {
+  var profile = {};
+  var baseUrl = 'test/fixtures';
+  var fileStat = fs.statSync(baseUrl);
+
+  if (fileStat.isDirectory()) {
+    profile = {
+      baseUrl: baseUrl,
+      out: 'tmp/requirejs-profile.js'
+    };
+  }
+
+  return profile;
+};

--- a/test/requirejs_test.js
+++ b/test/requirejs_test.js
@@ -27,5 +27,19 @@ exports['requirejs'] = {
     test.equal(expect, result, 'should process options with template variables.');
 
     test.done();
+  },
+
+  profile: function(test) {
+    'use strict';
+
+    var expect, result;
+
+    test.expect(1);
+
+    expect = 'define("hello",[],function(){return"hello"}),define("world",[],function(){return"world"}),require(["hello","world"],function(e,t){console.log(e,t)}),define("project",function(){});';
+    result = grunt.file.read('tmp/requirejs-profile.js');
+    test.equal(expect, result, 'should process options with buildProfile variables.');
+
+    test.done();
   }
 };


### PR DESCRIPTION
The purpose here is to be able to do some pre-processing prior to hitting requirejs.optimize() in order to create more complicated build options than might otherwise be possible.

In my case, I needed this functionality to do dependency path resolution, and then set the paths on the config.paths object.

I've included the ability to pass options to the build profile, and a switch to override the settings defined in grunt with those from the buildProfile. The default behavior is the grunt settings will trump anything spit out of the buildProfile.

A big difference between this and the r.js buildFile option is that this executes in a pure node environment, whereas the buildFile will be an r.js environment. Most importantly for me, buildFile wouldn't work because I needed to resolve paths relative to the buildProfile itself -- not the r.js directory.

Also included is a test, which passes for me.
