### PR TITLE
Add support for relative path in 'out' & 'paths' options

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,14 +34,14 @@ module.exports = function(grunt) {
         options: {
           baseUrl: 'test/fixtures',
           name: 'project',
-          out: 'tmp/requirejs.js'
+          out: '../../tmp/requirejs.js'
         }
       },
       template: {
         options: {
           baseUrl: 'test/fixtures',
           name: 'project',
-          out: 'tmp/requirejs-template.js'
+          out: '../../tmp/requirejs-template.js'
         }
       }
     },

--- a/tasks/requirejs.js
+++ b/tasks/requirejs.js
@@ -45,14 +45,6 @@ module.exports = function(grunt) {
       paths[key] = resolve(join(options.baseUrl, path));
     });
 
-    // if no out-file is provided, use the target name
-    var out = options.out || this.target;
-
-    // if trailing ".js" is missing on the outFile, append it
-    if(!(/\.js$/.test(out))) {
-      out = out + '.js';
-    }
-
     // make the out-file path absolute too
     options.out = resolve(join(options.baseUrl, options.out));
 


### PR DESCRIPTION
This PR solves the following issues:
- [x]  <del>If `out` options isn't provided, use target-name appended with `.js` as `out`.</del>
- [x] `paths` & `out` paths can be relative to the `baseUrl`, resolve them before starting the compilation.

``` javascript
grunt.initConfig({
    'requirejs' : {
        "options": {
            "baseUrl": "public",
            "paths": {
                "partials": "../build/templates",
                "templates": "../build/templates",
                "styles": "../build/styles"
            }
        },
        "app": {
            "options": {
                "out": "../build/app.min.js"
            }
        }
    }
});
```
