### PR TITLE
add extra option "fail" to provide a handler for when requirejs fails.

### DIFF
--- a/tasks/requirejs.js
+++ b/tasks/requirejs.js
@@ -31,10 +31,13 @@ module.exports = function(grunt) {
       logLevel: 0,
       done: function(done, response){
         done();
+      },
+      fail: function(done, err){
+        done(err);
       }
     });
     grunt.verbose.writeflags(options, 'Options');
 
-    requirejs.optimize(options, options.done.bind(null, done));
+    requirejs.optimize(options, options.done.bind(null, done), options.fail.bind(null,done));
   });
 };


### PR DESCRIPTION
Adding a "fail" option to pass to the task will allow for a user to attach their own error handler to the task. requirejs.optimize() will then be passed this "fail" function as its 3rd argument. I like to use supplemental notification systems (i.e. node-osx-notifier) and something like this would prove helpful.
