### PR TITLE
update requirejs dependency to v2.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "requirejs": "~2.1.0"
+    "requirejs": "~2.1.11"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.2.0",


### PR DESCRIPTION
[RequireJS v2.1.11 introduced a new option](http://jrburke.com/2014/02/16/requirejs-2.1.11-released/), `wrapShim`. Updating to the latest RequireJS makes that option available through this grunt task.

FWIW: I needed the option for Backbone extension libs since Backbone v1.1.1 started supporting AMD.
