### PR TITLE
Added warning on fail

### DIFF
--- a/tasks/requirejs.js
+++ b/tasks/requirejs.js
@@ -33,7 +33,15 @@ module.exports = function(grunt) {
         done();
       }
     });
+    // The following catches errors in the user-defined `done` function and outputs them.
+    var tryCatch = function(fn, done, output) {
+      try {
+        fn(done, output);
+      } catch(e) {
+        grunt.fail.warn('There was an error while processing your done function: "' + e + '"');
+      }
+    };
 
-    requirejs.optimize(options, options.done.bind(null, done));
+    requirejs.optimize(options, tryCatch.bind(null, options.done, done));
   });
 };


### PR DESCRIPTION
The issue in #37 is that the done function fails silently when there is an error. When this happens, it never fires the `done();` statement and any subsequent grunt tasks never run.

Wrapping the call in a try catch is ugly, but it's one way to catch the error and pass it off to the user.

No unit tests were added because it's supposed to fail, and the testing suite isn't set up to handle that right now. Over in uglify we use the [expectFail task](https://github.com/gruntjs/grunt-contrib-uglify/blob/master/Gruntfile.js#L209-L225); should that be added to this task as well? More generally should that `expectFail` task be abstracted to a shared library that all grunt-contribs can use?

//cc @tkellen
