### PR TITLE
Set default log level to WARN (or TRACE, for verbose)

### DIFF
--- a/tasks/requirejs.js
+++ b/tasks/requirejs.js
@@ -10,6 +10,7 @@ module.exports = function(grunt) {
   'use strict';
 
   var requirejs = require('requirejs');
+  var LOG_LEVEL_TRACE = 0, LOG_LEVEL_WARN = 2;
 
   // TODO: extend this to send build log to grunt.log.ok / grunt.log.error
   // by overriding the r.js logger (or submit issue to r.js to expand logging support)
@@ -28,7 +29,7 @@ module.exports = function(grunt) {
 
     var done = this.async();
     var options = this.options({
-      logLevel: 0,
+      logLevel: grunt.option('verbose') ? LOG_LEVEL_TRACE : LOG_LEVEL_WARN,
       done: function(done, response){
         done();
       }


### PR DESCRIPTION
This commit will result in a cleaner console output by setting the default log level to 'WARN' (2) instead of `TRACE` (0). If the client runs `grunt requirejs` with the `--verbose` flag, the default logLevel will be `TRACE` (0).

I believe this will better match a user's expectation, and will be more in line with the default console output of other grunt tasks.
