### PR TITLE
Add return to prevent double done() call

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ requirejs: {
         if (duplicates.length > 0) {
           grunt.log.subhead('Duplicates found in requirejs build:');
           grunt.log.warn(duplicates);
-          done(new Error('r.js built duplicate modules, please check the excludes option.'));
+          return done(new Error('r.js built duplicate modules, please check the excludes option.'));
         }
 
         done();


### PR DESCRIPTION
Add a return in the example error case so it doesn't fall through and immediately call `done()` again.
