### PR TITLE
Catch errors thrown by requirejs.optimize using errback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# grunt-contrib-requirejs v0.4.4 [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-requirejs.png?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-requirejs)
+# grunt-contrib-requirejs v0.4.4 [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-requirejs.svg?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-requirejs)
 
-> Optimize RequireJS projects using r.js.
+> Optimize RequireJS projects using r.js
 
 
 
 ## Getting Started
-This plugin requires Grunt `~0.4.0`
+This plugin requires Grunt `>=0.4.0`
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
@@ -62,14 +62,10 @@ requirejs: {
       done: function(done, output) {
         var duplicates = require('rjs-build-analysis').duplicates(output);
 
-        if (Object.keys(duplicates).length > 0) {
+        if (duplicates.length > 0) {
           grunt.log.subhead('Duplicates found in requirejs build:');
-          for (var key in duplicates) {
-            grunt.log.error(duplicates[key] + ": " + key);
-          }
+          grunt.log.warn(duplicates);
           return done(new Error('r.js built duplicate modules, please check the excludes option.'));
-        } else {
-          grunt.log.success("No duplicates found!");
         }
 
         done();
@@ -78,6 +74,24 @@ requirejs: {
   }
 }
 ```
+
+#### Error
+
+```js
+requirejs: {
+  compile: {
+    options: {
+      baseUrl: "path/to/base",
+      mainConfigFile: "path/to/config.js",
+      error: function(done, err) {
+        grunt.log.warn(err);
+        done();
+      }
+    }
+  }
+}
+```
+
 
 
 ## Release History
@@ -98,4 +112,4 @@ requirejs: {
 
 Task submitted by [Tyler Kellen](http://goingslowly.com/)
 
-*This file was generated on Fri Apr 25 2014 15:35:54.*
+*This file was generated on Tue Jul 21 2015 18:52:30.*

--- a/tasks/requirejs.js
+++ b/tasks/requirejs.js
@@ -30,12 +30,13 @@ module.exports = function(grunt) {
     var done = this.async();
     var options = this.options({
       logLevel: grunt.option('verbose') ? LOG_LEVEL_TRACE : LOG_LEVEL_WARN,
+      error: false,
       done: function(done, response){
         done();
       }
     });
     // The following catches errors in the user-defined `done` function and outputs them.
-    var tryCatch = function(fn, done, output) {
+    var tryCatchDone = function(fn, done, output) {
       try {
         fn(done, output);
       } catch(e) {
@@ -43,6 +44,21 @@ module.exports = function(grunt) {
       }
     };
 
-    requirejs.optimize(options, tryCatch.bind(null, options.done, done));
+    // The following catches errors in the user-defined `error` function and passes them.
+    // if the error function options is not set, this value should be undefined
+    var tryCatchError = function(fn, done, err) {
+      try {
+        fn(done, err);
+      } catch(e) {
+        grunt.fail.fatal('There was an error while processing your error function: "' + e + '"');
+      }
+    };
+
+    requirejs.optimize(
+            options,
+            tryCatchDone.bind(null, options.done, done ),
+            options.error ? tryCatchError.bind(null, options.error, done ):undefined
+    );
+
   });
 };


### PR DESCRIPTION
The reason for this update is to allow grunt-contrib-requirejs to fail gracefully when there is an r.js error.  Currently the node process is aborted; this behavior is undesirable in a development environment, especially when using a watch process.

The updates I've made are as described by the requirejs creator [(issue link)](https://github.com/jrburke/r.js/issues/335#ref-commit-679e66a) and have been implemented via a new option in order to not affect the current behavior.
