### PR TITLE
Made clear that usage of almond is not required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ requirejs: {
     options: {
       baseUrl: "path/to/base",
       mainConfigFile: "path/to/config.js",
-      name: "path/to/almond", // assumes a production build using almond
+      name: "path/to/almond", /* assumes a production build using almond, if you don't use almond, you 
+                                 need to set the "includes" or "modules" option instead of name */
       out: "path/to/optimized.js"
     }
   }


### PR DESCRIPTION
When reading the readme, I thought that using almond is mandatory because the first example uses it. This commit improves the comment to make clear that there are also other options.